### PR TITLE
Update locate dotnet logic

### DIFF
--- a/spacefx/_sdk_client.py
+++ b/spacefx/_sdk_client.py
@@ -16,7 +16,7 @@ DOTNET_DIR = shutil.which("dotnet")
 if not DOTNET_DIR:
     raise ValueError(f"Unable to find an installation of dotnet.  Please install dotnet so it's found within the system PATH")
 
-DOTNET_DIR = DOTNET_DIR.resolve(strict=True).parent
+DOTNET_DIR = Path(DOTNET_DIR).resolve(strict=True).parent
 DOTNET_DIR = os.path.join(DOTNET_DIR, "shared")
 
 if not os.path.exists(DOTNET_DIR):
@@ -40,7 +40,7 @@ for dirpath, dirnames, filenames in os.walk(os.path.join(DOTNET_DIR, 'Microsoft.
 
 
 # Load the client adapter library which is in the parent directory / spacefxClient
-base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'spacefxClient')
+base_dir = Path(__file__).parent / 'spacefxClient'
 
 # Find "spacesdk-client.dll" in any subdirectory
 spacesdk_client_dll = next(base_dir.rglob('spacesdk-client.dll'), None)


### PR DESCRIPTION
Updates the logic to find dotnet via the system path instead of within the current working directory.  This is because dotnet is installed in a different spot when the generated wheel is used by a Python App.